### PR TITLE
fix block error when orphan transaction depend on the same transaction

### DIFF
--- a/blockchain/template.go
+++ b/blockchain/template.go
@@ -796,11 +796,14 @@ func newBlockTemplate(chain *Blockchain, payoutAddresses []massutil.Address, tem
 					depList = list.New()
 					dependers[*originHash] = depList
 				}
-				depList.PushBack(prioItem)
 				if prioItem.dependsOn == nil {
 					prioItem.dependsOn = make(
 						map[wire.Hash]struct{})
 				}
+				if _, exists = prioItem.dependsOn[*originHash]; exists {
+					continue
+				}
+				depList.PushBack(prioItem)
 				prioItem.dependsOn[*originHash] = struct{}{}
 			}
 		}


### PR DESCRIPTION
## orphan transaction

 mempool:
```
        tx a                orphan tx
        in      out            in     out
        +-----+-----+       +-------+------+
        |     | 1   |------>| 1     |      |
        +-----+-----+       +-------+------+
        |     | 2   |------>| 2     |      |
        +-----+-----+       +-------+------+
                            | 3 
  ```

[btc code ](https://github.com/btcsuite/btcd/blob/e563459b72df634ca5731ac6c93e9ffbfd36dd93/mining/mining.go#L555)

Bug :

template.go 945L

```go
// Add transactions which depend on this one (and also do not
// have any other unsatisified dependencies) to the priority
// queue.
if deps != nil {
	for e := deps.Front(); e != nil; e = e.Next() {
		// Add the transaction to the priority queue if
		// there are no more dependencies after this
		// one.
		item := e.Value.(*txPrioItem)
		delete(item.dependsOn, *tx.Hash())
		if len(item.dependsOn) == 0 {
			heap.Push(priorityQueue, item)
		}
	}
}
```
           